### PR TITLE
Adding the ability to load a schema from a file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 graphql-autocomplete
 ```
 
-Autocomplete and lint from a GraphQL endpoint in atom.
+Autocomplete and lint from a GraphQL endpoint or static JSON introspection query in atom.
 
 ![](https://github.com/nicolaslopezj/atom-graphql-autocomplete/blob/master/resources/example.png)
 
@@ -12,12 +12,22 @@ Autocomplete and lint from a GraphQL endpoint in atom.
 
 - Create a ```.graphqlrc``` file in the root of your project
 
-- Add the ```endpoint```:
+- For querying against a live endpoint, add the ```endpoint```:
 
 ```json
 {
   "request": {
     "url": "http://localhost:3000/graphql"
+  }
+}
+```
+
+- For using a static file, add the `file path`:
+
+```json
+{
+  "file": {
+    "path": "./introspection.json"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Autocomplete and lint from a GraphQL endpoint or static JSON introspection query
 }
 ```
 
-- For using a static file, add the `file path`:
+- For using a static file, add the `file path` (can be relative to the project or the fully-qualified path):
 
 ```json
 {

--- a/lib/graphql/getSchema.js
+++ b/lib/graphql/getSchema.js
@@ -5,6 +5,7 @@
 import {buildClientSchema, introspectionQuery} from 'graphql'
 import fs from 'fs-plus'
 import _ from 'underscore'
+import path from 'path'
 
 let id = 1
 const addId = _.debounce(() => id++, 10 * 1000 /* 10 seconds */)
@@ -12,6 +13,8 @@ const getId = function () {
   addId()
   return id
 }
+
+const buildClientFromIntrospection = ({ data }) => buildClientSchema(data)
 
 const getConfig = function () {
   try {
@@ -36,8 +39,27 @@ const get = async function ({request}) {
     credentials: 'include'
   })
   const introspection = await result.json()
-  const schema = buildClientSchema(introspection.data)
-  return schema
+  return buildClientFromIntrospection(introspection)
+}
+
+const getFromFSPath = (filePath) => {
+  const projectPath = atom.project.getPaths()[0]
+  const fqPath = fs.isAbsolute(filePath)
+    ? filePath
+    : path.join(projectPath, filePath)
+
+  if (!fs.existsSync(fqPath)) {
+    console.warn(`Error reading graphql introspection JSON from: ${fqPath}`)
+    return {}
+  }
+
+  try {
+    const data = JSON.parse(fs.readFileSync(fqPath).toString())
+    return buildClientFromIntrospection({ data })
+  } catch (error) {
+    console.warn(`Error deserializing graphql introspection json from: ${fqPath} ${error.message}`)
+    return {}
+  }
 }
 
 let schema = null
@@ -46,6 +68,7 @@ let lastId = null
 export default async function () {
   const id = getId()
   const config = getConfig()
+  if (config.file && config.file.path) return getFromFSPath(config.file.path)
   if (!config.request) return null
   if (lastId === id && schema) return schema
   lastId = id


### PR DESCRIPTION
[eslint-plugin-graphql](https://github.com/apollographql/eslint-plugin-graphql)'s convention is to load the schema/introspection query from a static file inside the project. Because of that, it'd be nice if consumers of that plugin were able to reuse their static introspection JSON for this autocomplete plugin.

I've updated the README to include documentation, but to make it clear:

```json
{
  "file": {
    "path": "some/file/path"
  }
}
```