### PR TITLE
Fix loading schema from introspection json file

### DIFF
--- a/lib/graphql/getSchema.js
+++ b/lib/graphql/getSchema.js
@@ -52,7 +52,7 @@ const getFromFSPath = filePath => {
   }
 
   try {
-    const data = JSON.parse(fs.readFileSync(fqPath).toString())
+    const { data } = JSON.parse(fs.readFileSync(fqPath).toString())
     return buildClientFromIntrospection({data})
   } catch (error) {
     console.warn(`Error deserializing graphql introspection json from: ${fqPath} ${error.message}`)


### PR DESCRIPTION
Introspection JSON files has this structure and not immediatelty the content of `data` field
```json
{
"data" : {},
"extensions": {}
}
```